### PR TITLE
check json files with jq

### DIFF
--- a/.github/json_check.sh
+++ b/.github/json_check.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+JSON_DIR=$1
+RC=0
+
+for JSON_FILE in $(ls "$JSON_DIR"); do
+    jq type 1>/dev/null < "$JSON_DIR/$JSON_FILE"
+    if [ $? -gt 0 ]; then
+        echo "Error in file: $JSON_DIR/$JSON_FILE"
+        RC=1
+    fi
+done
+
+exit "$RC"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+---
+name: Lint
+
+on:
+  pull_request:
+    paths:
+      - "secjson/**/**"
+
+jobs:
+  build:
+    name: JSON lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: Check JSON files
+        run: .github/json_check.sh secjson


### PR DESCRIPTION
I added a simple JSON validator with `jq` utility. The script iterates over json files and exits with an error if any of JSON files in `secjson` is not valid. E.g.:

```
jq: parse error: Invalid numeric literal at line 23, column 60
Error in file: secjson/CVE-2009-3555.json
jq: parse error: Invalid literal at line 6, column 45
Error in file: secjson/CVE-2022-4450.json
jq: parse error: Invalid numeric literal at line 57, column 1068
Error in file: secjson/CVE-2024-6119.json
```